### PR TITLE
Allow chaining of scopes.

### DIFF
--- a/jquery.available.full.js
+++ b/jquery.available.full.js
@@ -19,13 +19,13 @@
             // if the element is not null, the opening tag is guaranteed to exist, but not necessarily the closing tag
             // so we also check for the next element, or isReady just in case it's the last element on the page
             // if turbo mode is used (list[i][2]), then we only check for the opening tag, this makes prepending or changing css "instant" on larger nodes
-            if ($(queue[i][0])[0] && (queue[i][2] || $(queue[i][0]).next()[0] || $.isReady)) {
+            if (queue[i][0].find(queue[i][1])[0] && (queue[i][3] || $(queue[i][1]).next()[0] || $.isReady)) {
 
                 // if the element is ready, apply the function within the context of the original selector
                 // we only match the first element because otherwise we can't be sure if we got everything (if it's a class or tag name)
                 // wrapping the apply in a try-catch will prevent a race condition if there is an error in the callback, and we'll log the error to console if it's there
                 try {
-                    queue[i][1].apply($(queue[i][0]).eq(0));
+                    queue[i][2].apply(queue[i][0].find(queue[i][1]).eq(0));
                 } catch (e) {
                     if (typeof window.console !== 'undefined') {
                         window.console.log(e);
@@ -55,7 +55,7 @@
         turbo = turbo || false;
 
         // add the selector, the function, and whether or not turbo should be used to the queue
-        queue.push([this.selector, fn, turbo]);
+        queue.push([this.prevObject, this.selector, fn, turbo]);
 
         // start polling
         check();


### PR DESCRIPTION
This allows the selector to be based on parent contexts. For example, we can do $('li').find('.foo').available(handler), that selects only inside the li, and not any .foo on page.
